### PR TITLE
Publication abbreviation + ZDB-ID

### DIFF
--- a/docs/cerif_xml_publication_entity.rst
+++ b/docs/cerif_xml_publication_entity.rst
@@ -107,6 +107,15 @@ Subtitle
 
 
 
+NameAbbreviation
+^^^^^^^^
+:Description: The abbreviation of the title of the publication
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``NameAbbreviation`` as a multilingual string
+:CERIF: the ResultPublication.NameAbbreviation attribute (`<https://w3id.org/cerif/model#ResultPublication.NameAbbreviation>`_)
+
+
+
 PublishedIn
 ^^^^^^^^^^^
 :Description: The source (another Publication) where this publication appeared. E.g. a journal article lists here the journal where it appeared. To be used for a publishing channel.
@@ -241,6 +250,16 @@ ISSN
 :Representation: XML element ``ISSN``
 :CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
 :Format: regular expression ``\d{4}-?\d{3}[\dX]`` and length between 8 and 9 characters (as per `<https://data.crossref.org/reports/help/schema_doc/4.4.1/schema_4_4_1.html#issn_t>`_)
+
+
+
+ZDB-ID
+^^^^^^
+:Description: The German National Serials Database identifier
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``ZDB-ID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``\d{1,7}-[Xx\d]`` (as per `<https://www.wikidata.org/wiki/Property:P1042>`_)
 
 
 

--- a/samples/openaire_cerif_xml_example_publications.xml
+++ b/samples/openaire_cerif_xml_example_publications.xml
@@ -23,7 +23,9 @@
 						<Publication id="894490"><!-- Int J Digital Curation -->
 							<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">http://purl.org/coar/resource_type/c_0640<!-- journal --></Type>
 							<Title xml:lang="en">The International Journal of Digital Curation</Title>
+							<NameAbbreviation xml:lang="en">IJDC</NameAbbreviation>
 							<ISSN>1746-8256</ISSN>
+							<ZDB-ID>2266735-0</ZDB-ID>
 						</Publication>
 					</PublishedIn>
 					<PublicationDate>2013-06-14</PublicationDate>

--- a/schemas/includes/publication-identifiers.xsd
+++ b/schemas/includes/publication-identifiers.xsd
@@ -82,6 +82,8 @@
 
             <xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#URN" minOccurs="0" name="URN" type="cfString__Type"/>
 
+            <xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ZDBID" minOccurs="0" name="ZDB-ID" type="ZDBID__Type"/>
+
 <!-- A skeleton for contributing new identifier types
 			## ideally please submit a GitHub pull request with branch called 'add-XXX'
 			## but we will welcome your contribution no matter how you choose to communicate it to us  
@@ -118,4 +120,25 @@
 		</xs:sequence>
 	</xs:group>
     
+	<xs:complexType name="ZDBID__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the ZDB identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="13609b36-0428-4003-8bb1-39174f10a211">
+					<cf:Name xml:lang="en">The ZDB identifier</cf:Name>
+					<cf:Description xml:lang="en">Service that provides identifiers for serials German National Serials Database.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="\d{1,7}-[Xx\d]">
+					<xs:annotation>
+						<xs:documentation source="https://www.wikidata.org/wiki/Property:P1042"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+
 </xs:schema>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -676,7 +676,7 @@ This entity typically represents the granularity level of a single published ite
 
 						<xs:element cflink:attribute="https://w3id.org/cerif/model#ResultPublication.NameAbbreviation" maxOccurs="unbounded" minOccurs="0" name="NameAbbreviation" type="cfMLangString__Type">
 							<xs:annotation>
-								<xs:documentation>The abbreviation of the title of the publication</xs:documentation>
+								<xs:documentation>The abbreviation of the title of the publication. E.g. the acronym of a journal.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -674,6 +674,12 @@ This entity typically represents the granularity level of a single published ite
 							</xs:annotation>
 						</xs:element>
 
+						<xs:element cflink:attribute="https://w3id.org/cerif/model#ResultPublication.NameAbbreviation" maxOccurs="unbounded" minOccurs="0" name="NameAbbreviation" type="cfMLangString__Type">
+							<xs:annotation>
+								<xs:documentation>The abbreviation of the title of the publication</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+
 						<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/Inter-PublicationRelations#Publication):1" minOccurs="0" name="PublishedIn">
 							<xs:annotation>
 								<xs:documentation>The source (another Publication) where this publication appeared. E.g. a journal article lists here the journal where it appeared. To be used for a publishing channel.</xs:documentation>


### PR DESCRIPTION
Two updates done here as discussed during CERIF TG meeting (see #65 ):

- add a new attribute (publication.NameAbbreviation) to allow abbreviation for journals
- add a new identifier type for publication: ZDB-ID

Documentation + example have been updated accordingly.