### PR TITLE
Fix orgunits examples adding the identifier type for the Website

### DIFF
--- a/samples/openaire_cerif_xml_example_orgunits.xml
+++ b/samples/openaire_cerif_xml_example_orgunits.xml
@@ -20,7 +20,7 @@
 					<Acronym>NKUA</Acronym>
 					<Name xml:lang="el">ΕΘΝΙΚΟ ΚΑΙ ΚΑΠΟΔΙΣΤΡΙΑΚΟ ΠΑΝΕΠΙΣΤΗΜΙΟ ΑΘΗΝΩΝ</Name>
 					<Name xml:lang="en" trans="h">NATIONAL AND KAPODISTRIAN UNIVERSITY OF ATHENS</Name>
-					<Identifier type="">http://www.uoa.gr</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.uoa.gr</Identifier>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -36,7 +36,7 @@
 					<Acronym>CNR</Acronym>
 					<Name xml:lang="it">CONSIGLIO NAZIONALE DELLE RICERCHE</Name>
 					<Name xml:lang="en" trans="h">NATIONAL RESEARCH COUNCIL</Name>
-					<Identifier type="">http://www.cnr.it</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.cnr.it</Identifier>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -51,7 +51,7 @@
 					<Acronym>EKT</Acronym>
 					<Name xml:lang="en" trans="h">National Documentation Centre</Name>
 					<Name xml:lang="el">Εθνικό Κέντρο Τεκμηρίωσης</Name>
-					<Identifier type="">http://www.ekt.gr</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.ekt.gr</Identifier>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -65,7 +65,7 @@
 				<OrgUnit xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="312348">
 					<Acronym>UKOLN</Acronym>
 					<Name xml:lang="en">UKOLN</Name>
-					<Identifier type="">http://www.ukoln.ac.uk</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.ukoln.ac.uk</Identifier>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -103,7 +103,7 @@
 		            <Name xml:lang="sv">Europeiska kommissionen</Name>
 		            <Name xml:lang="hr">Europska komisija</Name>
 					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
-					<Identifier type="">https://europa.eu/</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">https://europa.eu/</Identifier>
 				</OrgUnit>
 			</metadata>
 		</record>

--- a/samples/openaire_cerif_xml_example_projects.xml
+++ b/samples/openaire_cerif_xml_example_projects.xml
@@ -19,7 +19,7 @@
 					<Acronym>OpenAIREplus</Acronym>
 					<Title xml:lang="en">2nd-Generation Open Access Infrastructure for Research in Europe</Title>
 					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#ProjectReference">283595</Identifier>
-					<Identifier type="">http://www.openaire.eu</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.openaire.eu</Identifier>
 					<StartDate>2011-12-01</StartDate>
 					<EndDate>2014-05-31</EndDate>
 					<Consortium>
@@ -103,7 +103,7 @@
 					<Title xml:lang="en">Open Access Infrastructure for Research in Europe</Title>
 					<Title xml:lang="el">Υποδομή Ανοικτής Πρόσβασης για την Έρευνα στην Ευρώπη</Title>
 					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#ProjectReference">246686</Identifier>
-					<Identifier type="">http://www.openaire.eu</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.openaire.eu</Identifier>
 					<StartDate>2009-12-01</StartDate>
 					<EndDate>2012-11-30</EndDate>
 					<Consortium>
@@ -185,7 +185,7 @@
 					<Acronym>EUFAR</Acronym>
 					<Title xml:lang="en">European Facility for Airborne Research in Environmental and Geoscience</Title>
 					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#ProjectReference">227159</Identifier>
-					<Identifier type="">http://www.eufar.net</Identifier><!-- FIXME -->
+					<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.eufar.net</Identifier>
 					<StartDate>2008-09-22</StartDate>
 					<EndDate>2013-09-30</EndDate>
 					<Consortium>
@@ -194,7 +194,7 @@
 								<Acronym>CNR</Acronym>
 								<Name xml:lang="it">CONSIGLIO NAZIONALE DELLE RICERCHE</Name>
 								<Name xml:lang="en" trans="h">NATIONAL RESEARCH COUNCIL</Name>
-								<Identifier type="">http://www.cnr.it</Identifier><!-- FIXME -->
+								<Identifier type="https://w3id.org/cerif/IdentifierTypes#Website">http://www.cnr.it</Identifier>
 							</OrgUnit>
 						</Partner>
 					</Consortium>


### PR DESCRIPTION
This is an alternative PR for #64 (other PR https://github.com/openaire/guidelines-cris-managers/pull/70 )

The ElectronicAddress currently doesn't support a type attribute so the aggregator can only rely on the urn format to guess the meaning of the content (website, email address, etc). To add a type attribute a change in the schema would be necessary.

In the Service representation we have introduced a WebsiteURL element directly mapped to the CERIF Federated Identifier
https://github.com/openaire/guidelines-cris-managers/blob/master/schemas/openaire-cerif-profile.xsd#L1464
should we use an uniform approach?