### PR TITLE
OrgUnit identifiers

### DIFF
--- a/schemas/includes/cerif-base-identifiers.xsd
+++ b/schemas/includes/cerif-base-identifiers.xsd
@@ -98,5 +98,26 @@
             </xs:simpleType>
         </xs:union>
     </xs:simpleType>
+    
+    <xs:complexType name="ISNI__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the ISNI identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="01ceb044-45b0-4ac9-91c1-d72edc5c9ed8">
+					<cf:Name xml:lang="en">The ISNI identifier</cf:Name>
+					<cf:Description xml:lang="en">The identifiers assigned to persons, legal entities and other named objects.  See http://www.isni.org/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="\d{4} \d{4} \d{4} \d{3}[\dX]">
+					<xs:annotation>
+						<xs:documentation source="https://www.wikidata.org/wiki/Property:P213"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
 
 </xs:schema>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -61,7 +61,7 @@
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistryID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -115,7 +115,7 @@
 			<xs:appinfo>
 				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
 					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
-					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+					<cf:Description xml:lang="en">The service of registering research objects and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
 				</cf:Service>
 			</xs:appinfo>
 		</xs:annotation>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -115,7 +115,7 @@
 			<xs:appinfo>
 				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
 					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
-					<cf:Description xml:lang="en">The service of registering research objects and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
 				</cf:Service>
 			</xs:appinfo>
 		</xs:annotation>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cf="urn:xmlns:org.eurocris.cerif" xmlns:cflink="https://w3id.org/cerif/annotations#"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xml:lang="en"
+	xsi:schemaLocation="http://www.w3.org/2001/XMLSchema https://www.w3.org/2001/XMLSchema.xsd">
+	<xs:annotation>
+		<xs:documentation>This is the XML Schema component for the OpenAIRE CERIF profile 1.1 which specifies the admissible organisation units identifiers.
+			For further description please see the main schema file.
+			This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0/).
+		</xs:documentation>
+	</xs:annotation>
+	
+	 <xs:include schemaLocation="../includes/cerif-base-identifiers.xsd">
+        <xs:annotation>
+            <xs:documentation>The basic types of identifiers for use with schemas.</xs:documentation>
+        </xs:annotation>
+    </xs:include>
+
+	<xs:include schemaLocation="../includes/cerif-commons.xsd">
+		<xs:annotation>
+			<xs:documentation>The common building blocks for any CERIF XML Schema.</xs:documentation>
+		</xs:annotation>
+	</xs:include>
+
+	<xs:group name="OrgUnitIdentifiers__Group">
+		<xs:sequence>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR" minOccurs="0" name="ROR" type="ROR__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ROR identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeROR" type="ROR__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ROR identifiers in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#GRID" minOccurs="0" name="GRID" type="GRID__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The GRID identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#GRID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeGRID" type="GRID__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The GRID identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI" minOccurs="0" name="ISNI" type="ISNI__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ISNI identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeISNI" type="ISNI__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ISNI identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry" minOccurs="0" name="FundRefRegistry" type="FundRefRegistry__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefRegistry" type="FundRefRegistry__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			
+<!-- A skeleton for contributing new identifier types
+			## ideally please submit a GitHub pull request with branch called 'add-XXX'
+			## but we will welcome your contribution no matter how you choose to communicate it to us
+			##
+			## Part one: the elements: first the straight one, then the alternative one
+			## @cflink:link: please replace UUU with a fitting URL that represents the identifier scheme
+			<xs:element cflink:identifier="true" cflink:link="UUU" minOccurs="0" name="XXX" type="XXX__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The XXX identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="UUU https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="XXX" type="XXX__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The XXX identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+ -->
+
+		</xs:sequence>
+	</xs:group>
+
+	<xs:complexType name="ROR__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the ROR identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="98bdad67-6967-40f4-81a6-0fec9cc49705">
+					<cf:Name xml:lang="en">The ROR identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://ror.org/about for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="https:\/\/ror\.org\/0[\da-hj-km-np-tv-zA-HJ-KM-NP-TV-Z]{6}\d{2}">
+					<xs:annotation>
+						<xs:documentation source="https://ror.org/facts/"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="GRID__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the GRID identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
+					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="grid\.\d{4,}\.[0-9a-f]{1,2}">
+					<xs:annotation>
+						<xs:documentation source="https://www.wikidata.org/wiki/Property_talk:P2427"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>						
+
+	<xs:complexType name="FundRefRegistry__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the FundRef Registry Identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="a5aefe76-9cf5-4fab-adb5-52a464884387">
+					<cf:Name xml:lang="en">The FundRef Registry Identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering funders and assigning identifiers to them. See https://www.crossref.org/services/funder-registry/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="https:\/\/doi.org\/10\.13039\/\d+">
+					<xs:annotation>
+						<xs:documentation source="https://www.crossref.org/display-guidelines/"/>
+						<xs:documentation source="https://www.wikidata.org/wiki/Q19822542"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+
+<!-- A skeleton for contributing new identifier types
+			## Part two: the XML Schema type for the identifiers
+	<xs:complexType name="XXX__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the XXX identifier</xs:documentation>
+			<xs:appinfo>
+				## @id: please generate a fresh Version 4 UUID (e.g. through the 'uuidgen | tr A-F a-f' linux or macOS commands or online at https://www.uuidgenerator.net/version4)
+				<cf:Service id="">
+					## please keep the cf:Name equal to the xs:documentation above (dropping the leading "The XML Schema type for "), per @xml:lang
+					<cf:Name xml:lang="en">The XXX identifier</cf:Name>
+					## please provide a short description of the scope of the identifier service and supply a pointer to a webpage with more details
+					<cf:Description xml:lang="en">The service of registering YYY and assigning identifiers to them.  See ZZZ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				## please supply a regular expression (in @value) the values shall match
+				<xs:pattern value="">
+					<xs:annotation>
+						## and document (in @source) where you got it from
+						<xs:documentation source=""/>
+					</xs:annotation>
+				</xs:pattern>
+				## or at least specify (in @value) the maximum length of the admissible values of the identifier
+				<xs:maxLength value=""/>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+ -->
+
+</xs:schema>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -23,12 +23,12 @@
 	<xs:group name="OrgUnitIdentifiers__Group">
 		<xs:sequence>
 
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR" minOccurs="0" name="ROR" type="ROR__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#RORID" minOccurs="0" name="RORID" type="RORID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The ROR identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeROR" type="ROR__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#RORID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeRORID" type="RORID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The ROR identifiers in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -56,12 +56,12 @@
 				</xs:annotation>
 			</xs:element>
 
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry" minOccurs="0" name="FundRefRegistry" type="FundRefRegistry__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID" minOccurs="0" name="FundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefRegistry" type="FundRefRegistry__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistryID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -88,7 +88,7 @@
 		</xs:sequence>
 	</xs:group>
 
-	<xs:complexType name="ROR__Type">
+	<xs:complexType name="RORID__Type">
 		<xs:annotation>
 			<xs:documentation xml:lang="en">The XML Schema type for the ROR identifier</xs:documentation>
 			<xs:appinfo>
@@ -130,7 +130,7 @@
 		</xs:simpleContent>
 	</xs:complexType>						
 
-	<xs:complexType name="FundRefRegistry__Type">
+	<xs:complexType name="FundRefID__Type">
 		<xs:annotation>
 			<xs:documentation xml:lang="en">The XML Schema type for the FundRef Registry Identifier</xs:documentation>
 			<xs:appinfo>

--- a/schemas/includes/person-identifiers.xsd
+++ b/schemas/includes/person-identifiers.xsd
@@ -8,6 +8,12 @@
 		</xs:documentation>
 	</xs:annotation>
 
+	 <xs:include schemaLocation="../includes/cerif-base-identifiers.xsd">
+        <xs:annotation>
+            <xs:documentation>The basic types of identifiers for use with schemas.</xs:documentation>
+        </xs:annotation>
+    </xs:include>
+	
 	<xs:include schemaLocation="../includes/cerif-commons.xsd">
 		<xs:annotation>
 			<xs:documentation>The common building blocks for any CERIF XML Schema.</xs:documentation>
@@ -150,27 +156,6 @@
 				<xs:pattern value="[0-9]{10,11}">
 					<xs:annotation>
 						<xs:documentation source="https://www.wikidata.org/wiki/Property:P1153"/>
-					</xs:annotation>
-				</xs:pattern>
-			</xs:restriction>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="ISNI__Type">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">The XML Schema type for the ISNI identifier</xs:documentation>
-			<xs:appinfo>
-				<cf:Service id="01ceb044-45b0-4ac9-91c1-d72edc5c9ed8">
-					<cf:Name xml:lang="en">The ISNI identifier</cf:Name>
-					<cf:Description xml:lang="en">The identifiers assigned to persons, legal entities and other named objects.  See http://www.isni.org/ for more details.</cf:Description>
-				</cf:Service>
-			</xs:appinfo>
-		</xs:annotation>
-		<xs:simpleContent>
-			<xs:restriction base="cfString__Type">
-				<xs:pattern value="[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]">
-					<xs:annotation>
-						<xs:documentation source="https://www.wikidata.org/wiki/Property:P213"/>
 					</xs:annotation>
 				</xs:pattern>
 			</xs:restriction>


### PR DESCRIPTION
orgunit identifiers added for ROR, GRID, FundRefRegistry
ISNI identifier moved to cerif-base-identifiers.xsd, used in
person-identifiers.xsd and orgunit-identifiers.xsd
#64 