### PR TITLE
more relaxed oai-identifier

### DIFF
--- a/schemas/cached/oai-identifier.xsd
+++ b/schemas/cached/oai-identifier.xsd
@@ -33,13 +33,13 @@
 
   <simpleType name="repositoryIdentifierType">
     <restriction base="string">
-      <pattern value="[a-zA-Z][a-zA-Z0-9\-]*(\.[a-zA-Z][a-zA-Z0-9\-]*)+"/>
+      <pattern value="[a-zA-Z0-9][a-zA-Z0-9\-]*(\.[a-zA-Z0-9][a-zA-Z0-9\-]*)+"/>
     </restriction>
   </simpleType>
 
   <simpleType name="sampleIdentifierType">
     <restriction base="string">
-      <pattern value="oai:[a-zA-Z][a-zA-Z0-9\-]*(\.[a-zA-Z][a-zA-Z0-9\-]*)+:[a-zA-Z0-9\-_\.!~\*&apos;\(\);/\?:@&amp;=\+$,%]+"/>
+      <pattern value="oai:[a-zA-Z0-9][a-zA-Z0-9\-]*(\.[a-zA-Z0-9][a-zA-Z0-9\-]*)+:[a-zA-Z0-9\-_\.!~\*&apos;\(\);/\?:@&amp;=\+$,%]+"/>
       <!--meta ., \, ?, *, +, {, } (, ), [ or ] -->
     </restriction>
   </simpleType>


### PR DESCRIPTION
A pull request to handle more relaxed OAI-identifier and OAI-sampleIdentifier in the cached version of oai-identifier.xsd .
This handles also #126 , at least for the [OpenAIRE CRIS Validator](https://github.com/EuroCRIS/openaire-cris-validator), since it uses the cached files.