### PR TITLE
Support dates in Products

### DIFF
--- a/conf/openaire-cerif-profile.xml
+++ b/conf/openaire-cerif-profile.xml
@@ -220,6 +220,68 @@
                     <xs:documentation>The open access type of the product</xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="Dates" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Dates or date ranges to describe temporal aspects of the product. Semantically follows the dateType construct from the DataCite Metadata Schema 4.4.
+                    
+If an embargo period is to be expressed, its start should be expressed by the ``startDate`` on ``Submitted`` or ``Accepted`` (as appropriate) and end is represented by the ``startDate`` on ``Available``.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+	            	<xs:sequence>
+	            		<xs:element name="Accepted" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Accepted)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` attribute for the date the publisher accepted the resource into their system.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Available" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Available)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` and possibly also ``endDate`` attributes for the dates the resource is or was publicly available.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Copyrighted" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Copyrighted)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` attribute to give the specific, documented date at which the resource receives a copyrighted status, if applicable</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Collected" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Collected)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource content was collected. To indicate precise or particular timeframes in which research was conducted.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Created" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Created)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource itself was put together.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Issued" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Issued)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` attribute for the date the resource was published or distributed, e.g. to a data centre.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Submitted" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Submitted)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` attribute for the date the creator submits the resource to the publisher. This could be different from Accepted if the publisher then applies a selection process.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Updated" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Updated)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range of the last update to the resource, when the resource is being added to.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Valid" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Valid)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to indicate the period in which the dataset or resource is accurate.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            		<xs:element name="Withdrawn" minOccurs="0" type="cfLink__BaseType" cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Withdrawn)">
+			                <xs:annotation>
+			                    <xs:documentation>Use the ``startDate`` attribute for the date the resource is removed.</xs:documentation>
+			                </xs:annotation>
+	            		</xs:element>
+	            	</xs:sequence>
+            	</xs:complexType>
+            </xs:element>
 		</Entity>
 
 		<Entity uri="https://w3id.org/cerif/model#ResultPatent" leaveOut="ReferencedBy Parts">

--- a/docs/cerif_xml_funding_entity.rst
+++ b/docs/cerif_xml_funding_entity.rst
@@ -118,7 +118,7 @@ Duration
 ^^^^^^^^
 :Description: Duration of the funding
 :Use: optional (0..1)
-:Representation: XML element ``Duration`` *TODO*
+:Representation: XML element ``Duration``
 :CERIF: the Funding_Classification linking entity (`<https://w3id.org/cerif/model#Funding_Classification>`_) with the `<https://w3id.org/cerif/vocab/Durations#FundingDuration>`_ semantics
 
 

--- a/docs/cerif_xml_product_entity.rst
+++ b/docs/cerif_xml_product_entity.rst
@@ -268,4 +268,102 @@ ns4:Access
 
 
 
+Dates
+^^^^^
+:Description: Dates or date ranges to describe temporal aspects of the product. Semantically follows the dateType construct from the DataCite Metadata Schema 4.4. If an embargo period is to be expressed, its start should be expressed by the ``startDate`` on ``Submitted`` or ``Accepted`` (as appropriate) and end is represented by the ``startDate`` on ``Available``.
+:Use: optional (0..1)
+:Representation: XML element ``Dates`` with  embedded XML elements ``Accepted`` or ``Available`` or ``Copyrighted`` or ``Collected`` or ``Created`` or ``Issued`` or ``Submitted`` or ``Updated`` or ``Valid`` or ``Withdrawn``
+
+
+
+Accepted
+--------
+:Description: Use the ``startDate`` attribute for the date the publisher accepted the resource into their system.
+:Use: optional (0..1)
+:Representation: XML element ``Accepted``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Accepted>`_ semantics
+
+
+
+Available
+---------
+:Description: Use the ``startDate`` and possibly also ``endDate`` attributes for the dates the resource is or was publicly available.
+:Use: optional (0..1)
+:Representation: XML element ``Available``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Available>`_ semantics
+
+
+
+Copyrighted
+-----------
+:Description: Use the ``startDate`` attribute to give the specific, documented date at which the resource receives a copyrighted status, if applicable
+:Use: optional (0..1)
+:Representation: XML element ``Copyrighted``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Copyrighted>`_ semantics
+
+
+
+Collected
+---------
+:Description: Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource content was collected. To indicate precise or particular timeframes in which research was conducted.
+:Use: optional (0..1)
+:Representation: XML element ``Collected``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Collected>`_ semantics
+
+
+
+Created
+-------
+:Description: Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource itself was put together.
+:Use: optional (0..1)
+:Representation: XML element ``Created``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Created>`_ semantics
+
+
+
+Issued
+------
+:Description: Use the ``startDate`` attribute for the date the resource was published or distributed, e.g. to a data centre.
+:Use: optional (0..1)
+:Representation: XML element ``Issued``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Issued>`_ semantics
+
+
+
+Submitted
+---------
+:Description: Use the ``startDate`` attribute for the date the creator submits the resource to the publisher. This could be different from Accepted if the publisher then applies a selection process.
+:Use: optional (0..1)
+:Representation: XML element ``Submitted``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Submitted>`_ semantics
+
+
+
+Updated
+-------
+:Description: Use the ``startDate`` and ``endDate`` attributes to describe the date range of the last update to the resource, when the resource is being added to.
+:Use: optional (0..1)
+:Representation: XML element ``Updated``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Updated>`_ semantics
+
+
+
+Valid
+-----
+:Description: Use the ``startDate`` and ``endDate`` attributes to indicate the period in which the dataset or resource is accurate.
+:Use: optional (0..1)
+:Representation: XML element ``Valid``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Valid>`_ semantics
+
+
+
+Withdrawn
+---------
+:Description: Use the ``startDate`` attribute for the date the resource is removed.
+:Use: optional (0..1)
+:Representation: XML element ``Withdrawn``
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Withdrawn>`_ semantics
+
+
+
 

--- a/samples/openaire_cerif_xml_example_products.xml
+++ b/samples/openaire_cerif_xml_example_products.xml
@@ -42,6 +42,9 @@ EUFAR brings together 32 European institutions and companies involved in airborn
 						</Equipment>
 					</GeneratedBy>
                     <Access xmlns="http://purl.org/coar/access_right">http://purl.org/coar/access_right/c_16ec<!-- restricted access --></Access>
+                    <Dates>
+                    	<Collected startDate="2010-03-01T16:57:14Z" endDate="2017-07-20T22:59:59Z"/>
+                    </Dates>
             	</Product>
             </metadata>
         </record>
@@ -93,6 +96,9 @@ EUFAR brings together 32 European institutions and companies involved in airborn
 					<Keyword xml:lang="en">Australia</Keyword>
 					<Keyword xml:lang="en">Northeast Queensland</Keyword>
 					<Keyword xml:lang="en">Lampropholis coggeri</Keyword>
+					<Dates>
+						<Available startDate="2011-12-05"/>
+					</Dates>
 				</Product>
         	</metadata>
         </record>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -1049,6 +1049,68 @@ This includes:
                                 <xs:documentation>The open access type of the product</xs:documentation>
                             </xs:annotation>
                         </xs:element>
+                        <xs:element minOccurs="0" name="Dates">
+                            <xs:annotation>
+                                <xs:documentation>Dates or date ranges to describe temporal aspects of the product. Semantically follows the dateType construct from the DataCite Metadata Schema 4.4.
+                    
+If an embargo period is to be expressed, its start should be expressed by the ``startDate`` on ``Submitted`` or ``Accepted`` (as appropriate) and end is represented by the ``startDate`` on ``Available``.
+                    </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Accepted)" minOccurs="0" name="Accepted" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` attribute for the date the publisher accepted the resource into their system.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Available)" minOccurs="0" name="Available" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` and possibly also ``endDate`` attributes for the dates the resource is or was publicly available.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Copyrighted)" minOccurs="0" name="Copyrighted" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` attribute to give the specific, documented date at which the resource receives a copyrighted status, if applicable</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Collected)" minOccurs="0" name="Collected" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource content was collected. To indicate precise or particular timeframes in which research was conducted.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Created)" minOccurs="0" name="Created" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range in which the resource itself was put together.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Issued)" minOccurs="0" name="Issued" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` attribute for the date the resource was published or distributed, e.g. to a data centre.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Submitted)" minOccurs="0" name="Submitted" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` attribute for the date the creator submits the resource to the publisher. This could be different from Accepted if the publisher then applies a selection process.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Updated)" minOccurs="0" name="Updated" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to describe the date range of the last update to the resource, when the resource is being added to.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Valid)" minOccurs="0" name="Valid" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` and ``endDate`` attributes to indicate the period in which the dataset or resource is accurate.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/DataCiteMetadataSchema_DateType#Withdrawn)" minOccurs="0" name="Withdrawn" type="cfLink__BaseType">
+                                        <xs:annotation>
+                                            <xs:documentation>Use the ``startDate`` attribute for the date the resource is removed.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:group ref="__TheRestGroup"/>
                     </xs:sequence>
                 </xs:extension>

--- a/schemas/scripts/xsd2cerif-rst.xsl
+++ b/schemas/scripts/xsd2cerif-rst.xsl
@@ -243,6 +243,7 @@ Internal Identifier
 			<xsl:when test="@type = 'cfLinkWithDisplayNameToPersonWithAffiliations__Type'"> with embedded XML element ``Person`` optionally followed by one or several ``Affiliation`` elements. A ``DisplayName`` may be specified, too.</xsl:when>
 			<xsl:when test="@type = 'cfLinkWithDisplayNameToPersonOrOrgUnit__Type'"> with embedded XML element ``OrgUnit`` or ``Person``. A ``DisplayName`` may be specified, too.</xsl:when>
 			<xsl:when test="@type = 'cfLinkWithDisplayNameToOrgUnit__Type'"> with embedded XML element ``OrgUnit``. A ``DisplayName`` may be specified, too.</xsl:when>
+            <xsl:when test="@type = 'cfLink__BaseType'"/>
             <xsl:when test="@type = 'cfString__Type'"/>
             <xsl:when test="@type = 'cfDate__Type'"/>
             <xsl:when test="not( @type )">


### PR DESCRIPTION
We're adding a `<Dates>` container that supports the ten different terms of the dateType vocabulary from the [DataCite Metadata Schema v.4.4](https://doi.org/10.14454/3w3z-sa82) as optional embedded XML elements, each supporting a `startDate` and optionally also `endDate` attribute.

Fixes #84