### PR TITLE
Upgrade Github Actions components from v2 to v3

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,12 +6,12 @@ jobs:
     name: validate
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout Supporting Repos
         run: |
           git clone https://github.com/eurocris/CERIF-TG-Tools.git ../CERIF-TG-Tools
           git clone https://github.com/eurocris/openaire-cris-validator.git ../openaire-cris-validator
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'


### PR DESCRIPTION
In order to get rid of a warning about an unsupported version of Node.js we follow the advice and upgrade the versions of the compontents:

1. [actions/checkout](https://github.com/actions/checkout) from v2 (currently on v2.7.0) to v3 (currently on v3.5.2)
2. [actions/setup-java](https://github.com/actions/setup-java) from v2 (currently on v2.5.1) to v3 (currently on v3.11.0)